### PR TITLE
Add page for catching replay routing errors.

### DIFF
--- a/web/main/templates/main/replay-error.html
+++ b/web/main/templates/main/replay-error.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}No Service Worker{% endblock %}
+{% block heading %}Trying to view a web archive?{% endblock %}
+
+{% block content %}
+  <p>
+    The web archive player didn't load properly: please <a href="#" onclick="event.preventDefault(); window.location.reload(true)">try again</a>.
+  </p>
+  <p class="small">
+    This usually happens when you "force" or "hard" refresh the page, e.g., by including your shift key, which disables the service worker used for playback. If you did not force-refresh, or if you continue to have trouble, <a href="mailto:{{ CONTACT_EMAIL }}?subject=Replay%20Attempt%20Not%20Reaching%20Service%20Worker">let us know</a>.
+  </p>
+{% endblock content %}

--- a/web/main/urls.py
+++ b/web/main/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path(f'{settings.API_PREFIX}/captures', views.CaptureListView.as_view(), name='captures'),
     path(f'{settings.API_PREFIX}/capture/<slug:jobid>/<int:index>', views.CaptureDetailView.as_view(), name='delete_capture'),
     path('replay/sw.js', views.render_sw, name='sw'),
+    path('replay/', views.replay_error, name='replay_error'),
 
     path('sign-up/', views.sign_up, name='sign_up'),
 

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -13,6 +13,7 @@ from django.http import (HttpResponseRedirect,  HttpResponseForbidden,
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
+from django.views.decorators.clickjacking import xframe_options_exempt
 
 from rest_framework.decorators import api_view
 from rest_framework.response import Response as ApiResponse
@@ -134,6 +135,15 @@ def render_sw(request):
     }, content_type='application/javascript')
 
 
+@perms_test({'results': {200: ['user', None]}})
+@xframe_options_exempt
+def replay_error(request):
+    """
+    The service worker should be installed and handle all requests to /replay?foo=bar,
+    but this route serves to catch any requests that fall through by accident
+    and communicate debugging suggestions to the user.
+    """
+    return render(request, 'main/replay-error.html')
 
 
 #


### PR DESCRIPTION
If you force-refresh in Firefox, the service worker is disabled, so `replay/?....` requests are routed to the app... which returns a 404, with `x-frame-options: deny`... which causes Firefox to deliver it's "we can't embed this in an iframe" page.

This PR adds a route that returns 200 and a message to the user with out the blocking x-frame header, so that the iframe loads successfully and the playback JS can continue as planned...... where the planned action is, in fact, to notice that the service worker isn't working, and reload the whole page. So, you'll see our error/message page for an instant, and then the whole page will refresh. Way low-priority plan is to replace that auto-refresh with either a scoped reload of just the iframe (if that works), or a view that lets the user trigger refresh themselves.