### PR TITLE
Expose RWP_BASE_URL to templates and upgrade to 1.1.2

### DIFF
--- a/web/config/settings/settings_base.py
+++ b/web/config/settings/settings_base.py
@@ -277,6 +277,7 @@ TEMPLATE_VISIBLE_SETTINGS = (
     'USE_ANALYTICS',
     'ACCESSIBILITY_POLICY_URL',
     'PASSWORD_RESET_TIMEOUT_DAYS',
+    'RWP_BASE_URL'
 )
 
 DEFAULT_FROM_EMAIL = 'info@perma.cc'
@@ -298,4 +299,4 @@ API_PREFIX = 'api'
 BACKEND_API = "http://capture-service"
 
 # Playback
-RWP_BASE_URL = "https://cdn.jsdelivr.net/npm/replaywebpage@1.1.1/"
+RWP_BASE_URL = "https://cdn.jsdelivr.net/npm/replaywebpage@1.1.2"

--- a/web/main/templates/main/dashboard.html
+++ b/web/main/templates/main/dashboard.html
@@ -5,7 +5,7 @@
 
 {% block header_scripts %}
   <script src="{% static 'js/app.js' %}"></script>
-  <script src="{{ rwp_base_url }}ui.js"></script>
+  <script src="{{ RWP_BASE_URL }}/ui.js"></script>
 {% endblock header_scripts %}
 
 {% block flex %}no{% endblock %}

--- a/web/main/templates/main/docs.html
+++ b/web/main/templates/main/docs.html
@@ -4,7 +4,7 @@
 {% block html-class%}docs{% endblock %}
 
 {% block header_scripts %}
-  <script src="{{ rwp_base_url }}ui.js"></script>
+  <script src="{{ RWP_BASE_URL }}/ui.js"></script>
 {% endblock header_scripts %}
 
 {% block flex %}no{% endblock %}
@@ -276,12 +276,12 @@ function isValidSignature(signature, data, signingKey, signingKeyAlgorithm){
 
     <ol>
       <li>The replay system requires you to host a single JavaScript file on your server, which visitors browsers will use to install the service worker that handles playbacks. We recommend putting it in an empty directory, for example at <code>/replay/sw.js</code>. This file must be named <code>sw.js</code>, and it should contain the following:
-<pre><code>importScripts('https://cdn.jsdelivr.net/npm/replaywebpage@1.1.0/sw.js');
+<pre><code>importScripts("{{ RWP_BASE_URL }}/sw.js");
 </code></pre></li>
 
     <li>Each page that will contain embedded archives should include the following script and should also set the height for the <code>replay-web-page</code> tag to ensure a minimum height.
     (600px is used as an example here).
-<pre><code>&lt;script src="https://cdn.jsdelivr.net/npm/replaywebpage@1.1.0/ui.js"&gt;&lt;/script&gt;
+<pre><code>&lt;script src="{{ RWP_BASE_URL }}/ui.js"&gt;&lt;/script&gt;
 &lt;style&gt;
   replay-web-page {
     height: 600px;

--- a/web/main/templates/main/sw.js
+++ b/web/main/templates/main/sw.js
@@ -1,1 +1,1 @@
-importScripts("{{ rwp_base_url }}sw.js");
+importScripts("{{ RWP_BASE_URL }}/sw.js");

--- a/web/main/views.py
+++ b/web/main/views.py
@@ -414,9 +414,7 @@ def index(request):
     ... ])
     """
     if request.user.is_authenticated:
-        return render(request, 'main/dashboard.html', {
-            'rwp_base_url': settings.RWP_BASE_URL,
-        })
+        return render(request, 'main/dashboard.html')
     else:
         return render(request, 'generic.html', {
             'heading': settings.APP_NAME,
@@ -426,9 +424,7 @@ def index(request):
 
 @perms_test({'results': {200: ['user', None]}})
 def docs(request):
-    return render(request, 'main/docs.html', {
-        'rwp_base_url': settings.RWP_BASE_URL
-    })
+    return render(request, 'main/docs.html')
 
 
 @perms_test({'results': {200: ['user', None]}})
@@ -436,9 +432,7 @@ def render_sw(request):
     """
     Render the service worker in the root replay /replay/ path
     """
-    return render(request, 'main/sw.js', {
-        'rwp_base_url': settings.RWP_BASE_URL
-    }, content_type='application/javascript')
+    return render(request, 'main/sw.js', content_type='application/javascript')
 
 
 @perms_test({'results': {200: ['user', None]}})


### PR DESCRIPTION
expose RWP_BASE_URL to templates, use in all templates directly
use RWP_BASE_URL in doc examples
store version w/o trailing slash for easier template use