### PR TITLE
Serve the service worker from Django, for the time being.

### DIFF
--- a/web/frontend/src/components/CaptureListItem.vue
+++ b/web/frontend/src/components/CaptureListItem.vue
@@ -28,7 +28,7 @@
       <replay-web-page v-if="downloadUrl"
         :source="downloadUrl"
         :url="url"
-        replaybase="/vite/src/config/"
+        replaybase="/replay/"
         class="replay contextItem"/>
     </td>
   </tr>

--- a/web/frontend/src/config/sw.js
+++ b/web/frontend/src/config/sw.js
@@ -1,1 +1,0 @@
-importScripts("https://cdn.jsdelivr.net/npm/replaywebpage@1.3.9/sw.js");


### PR DESCRIPTION
Right now, the `replaybase` is [hard-coded](https://github.com/harvard-lil/perma-capture/blob/518c98a4c00f5e35175c521221cedf3022d7a3c5/web/frontend/src/components/CaptureListItem.vue#L31) in such a way that Vite can find the SW worker in dev... but so far as I can tell `sw.js` is not included in the built JS at all.

I unsuccessfully tried two strategies:

a) Add `sw.js` as a second entrypoint in `vite.config.js`:
```
        input: {
          main: 'src/main.ts',
          sw: 'src/config/sw.js'
        }
```
While that adds includes `sw.js` in the built assets, it won't work: the replay code expects to be handed a path to which it can append `sw.js` verbatim, whereas this would let us pass it a route straight to the caching-busting hashed js file itself. I don't think a second entrypoint can be made to work without a change to replayweb.page

b) Import [`sw.js` as a URL](https://vitejs.dev/guide/assets.html#importing-asset-as-url) in CaptureListItem, and passing that path to the component.
```
      <replay-web-page v-if="downloadUrl"
        :source="downloadUrl"
        :url="url"
        :replaybase="replaybase"
 
...  

import swURL from '../config/sw.js?url'

export default {
  props: ['capture'],
  data: () => ({
    displayContext: false,
    replaybase: swURL.substring(0, swURL.lastIndexOf('/') + 1)
  }),
```
That works in dev, but not with the built JS: the attempt to install the service worker is messed up, evidently scrambled somehow via the build process:
![image](https://user-images.githubusercontent.com/11020492/116138176-799a4c00-a6a2-11eb-85f6-7383bbf2f39b.png)

A third approach might be to add a route to the router whose job is to serve up a component... but I'm not sure Vue routes are intended to work that way...

Pending more experimentation and research, this PR reverts to our original behavior: the service worker js is served via Django. 