### PR TITLE
Upgrade to latest Browsertrix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,6 @@ services:
     environment:
       - DOCKERIZED=true
       - HOST_DIRECTORY=${HOST_DIRECTORY:-perma-capture}
-      - BROWSERTRIX_INTERNAL_DATA_DIR=/tmp/data
-      - BROWSERTRIX_ENTRYPOINT=${PWD}/docker/browsertrix/entrypoint.sh
       - TEST_CAPTURE_TARGET_DOMAINS=capture-target-1.test,capture-target-2.test,capture-target-3.test,capture-target-4.test
     volumes:
       - ./web:/app/web:delegated

--- a/docker/browsertrix/entrypoint.sh
+++ b/docker/browsertrix/entrypoint.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-# see https://docs.docker.com/engine/reference/builder/#entrypoint
-set -e
-
-# Initialize the data directory
-mkdir -p $DATA_DIR
-
-# Exec the original command
-exec su -c "$*"

--- a/web/config/settings/settings_base.py
+++ b/web/config/settings/settings_base.py
@@ -303,11 +303,8 @@ DEFAULT_S3_STORAGE = {
 OVERRIDE_STORAGE_NETLOC = None
 
 # Browsertrix
-BROWSERTRIX_IMAGE = 'registry.lil.tools/webrecorder/browsertrix-crawler:0.3.2'
+BROWSERTRIX_IMAGE = 'registry.lil.tools/webrecorder/browsertrix-crawler:0.4.3'
 BROWSERTRIX_DOCKER_NETWORK = None
-
-BROWSERTRIX_INTERNAL_DATA_DIR = os.environ.get('BROWSERTRIX_INTERNAL_DATA_DIR')
-BROWSERTRIX_ENTRYPOINT = os.environ.get('BROWSERTRIX_ENTRYPOINT')
 BROWSERTRIX_TIMEOUT_SECONDS = 270
 
 LAUNCH_CAPTURE_JOBS = True


### PR DESCRIPTION
This will fail until `registry.lil.tools/webrecorder/browsertrix-crawler:0.4.3` is present.

If `BROWSERTRIX_INTERNAL_DATA_DIR` is being set for any tiers... no need, we can lose that setting.

For posterity: the upgrade didn't work initially because `exec su -c "$*"`, found in the now-unnecessary entrypoint.sh, was working somehow differently with this ubuntu image than with the former image, which Ilya kindly discovered. Switching to `exec bash -c "$*"` works... but I'm just losing the entrypoint entirely and using `/tmp` instead... The only reason we didn't want to do that before was because we were doing stuff with volumes, and mounting `/tmp` resulted in clutter: not an issue now!