### PR TITLE
Constrain capture job list and make scrollable...

### DIFF
--- a/web/frontend/src/components/CaptureList.vue
+++ b/web/frontend/src/components/CaptureList.vue
@@ -3,7 +3,7 @@
     <header class="captures-header">
       <h2 class="list-title">Capture history</h2>
     </header>
-    <ul>
+    <ul ref="captureList" :class="{'scrollable': scrollable, 'scrolled': scrolled}" @scroll="applyScrollStyles">
       <CaptureListItem
           v-for="capture in captures(sortBy, sortDesc)"
           :key="capture.id"
@@ -36,7 +36,9 @@ export default {
       label: 'Label',
       capture_oembed_view: 'Embedded Version',
       created_at: 'Created At'
-    }
+    },
+    scrollable: false,
+    scrolled: false
   }),
   computed: {
     ...mapGetters({
@@ -81,6 +83,22 @@ export default {
       //   this.loading = true
       //   this.pageForward().then(() => this.loading = false)
       // }
+    },
+    checkIsScrollable() {
+      this.$nextTick(function () {
+        if (!this.$store.getters.isSmallestScreen && this.$refs.captureList.scrollHeight > (0.9 * this.$store.getters.viewportHeight)){
+          this.scrollable = true;
+        } else {
+          this.scrollable = false;
+        }
+      })
+    },
+    applyScrollStyles(e) {
+      if (e.target.scrollTop > 0) {
+        this.scrolled = true;
+      } else {
+        this.scrolled = false;
+      }
     }
   },
   watch: {
@@ -113,9 +131,20 @@ export default {
   created() {
     this.list().then(() => this.loading = false)
   },
+  mounted() {
+    this.$nextTick(function () {
+      window.addEventListener('resize', this.checkIsScrollable);
+    })
+  },
+  updated() {
+    this.$nextTick(function () {
+      this.checkIsScrollable()
+    })
+  },
   unmounted() {
-    this.clearScrollListener()
-    this.clearProcessingPoll()
+    this.clearScrollListener();
+    this.clearProcessingPoll();
+    window.removeEventListener('resize', this.checkIsScrollable);
   }
 }
 </script>

--- a/web/frontend/src/components/TheDashboard.vue
+++ b/web/frontend/src/components/TheDashboard.vue
@@ -29,10 +29,12 @@ export default {
   },
 
   mounted() {
-    this.$store.commit('setWindowWidth')
+    this.$store.commit('setWindowWidth');
+    this.$store.commit('setViewportHeight');
     this.$nextTick(() => {
       window.addEventListener('resize', debounce(() => {
-            this.$store.commit('setWindowWidth')
+            this.$store.commit('setWindowWidth');
+            this.$store.commit('setViewportHeight');
           }, 250)
       );
     });

--- a/web/frontend/src/store/index.ts
+++ b/web/frontend/src/store/index.ts
@@ -19,6 +19,7 @@ export default createStore({
       xl: 1400-1
     },
     windowWidth: 'xl',
+    viewportHeight: 0
   },
   mutations: {
     setDisplayedCapture: (state, capture) => {
@@ -36,6 +37,9 @@ export default createStore({
       } else {
         state.windowWidth = 'xl';
       }
+    },
+    setViewportHeight: (state) => {
+      state.viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
     }
   },
   actions: {},
@@ -45,6 +49,12 @@ export default createStore({
     },
     isMobile: (state) => {
       return state.windowWidth === 'md' || state.windowWidth === 'sm' || state.windowWidth === 'xs';
+    },
+    isSmallestScreen: (state) => {
+      return state.windowWidth === 'xs';
+    },
+    viewportHeight: (state) => {
+      return state.viewportHeight;
     }
   },
 })

--- a/web/frontend/src/styles/_pages/dashboard.scss
+++ b/web/frontend/src/styles/_pages/dashboard.scss
@@ -69,12 +69,35 @@
     .captures-header {
       padding-left: 1em;
       padding-top: 1em;
+      margin-bottom: 1em;
 
       .list-title {
         font-weight: $font-weight-normal;
         font-size: 1.4em;
       }
     }
+
+    .scrollable {
+      overflow-y: scroll;
+
+      margin-bottom: 0;
+      height: 80vh;
+
+      /* Subtle shadow at the bottom of the list */
+      box-shadow: 0 15px 15px -15px rgba(0,0,0,0.1);
+    }
+
+    .scrolled {
+      /* Subtle shadow between header and list, and at the bottom of the list */
+      box-shadow:
+        0 15px 15px -15px rgba(0,0,0,0.1),
+        0 -2px 2px -2px rgba(0,0,0,0.2);
+    }
+
+    li:first-child .content {
+      margin-top: -0.5em;
+    }
+
   }
 
   .capture-detail-container {


### PR DESCRIPTION
... except on the smallest screens.

![image](https://user-images.githubusercontent.com/11020492/128565205-5f7577ed-c58d-4db3-829e-023778b30dc8.png)

![image](https://user-images.githubusercontent.com/11020492/128565224-08da21a8-f53b-496d-81e8-5a58becad324.png)

So, when you toggle the details open, you can see them, instead of having to scroll all the way to the top of the viewport.

This will also give us the option of adding a footer.